### PR TITLE
Add mini.statusline highlight groups to highlights.lua

### DIFF
--- a/lua/nymph/highlights.lua
+++ b/lua/nymph/highlights.lua
@@ -243,6 +243,19 @@ function T.set_colors(p)
 		HopUnmatched = { fg = p.fg_alt },
 		HopCursor = { bg = p.fg },
 		HopPreview = { fg = p.magenta }
+
+		-- mini.statusline: https://github.com/echasnovski/mini.nvim
+		MiniStatusLineModeNormal = { fg = p.cyan, bg = p.bg_alt },
+		MiniStatusLineModeVisual = { fg = p.yellow, bg = p.bg_alt },
+		MiniStatusLineModeInsert = { fg = p.red, bg = p.bg_alt },
+		MiniStatusLineModeReplace = { fg = p.magenta, bg = p.bg_alt },
+		MiniStatusLineModeCommand = { fg = p.blue, bg = p.bg_alt },
+		MiniStatusLineModeOther = { fg = p.green, bg = p.bg_alt },
+		MiniStatusLineDevinfo = { fg = p.fg, bg = p.bg_alt },
+		MiniStatusLineFilename = { fg = p.fg, bg = p.bg_alt },
+		MiniStatusLineFileinfo = { fg = p.fg, bg = p.bg_alt },
+		MiniStatusLineInactive = { fg = p.fg, bg = p.bg_alt },
+
 	}
 
 	vim.g.terminal_color_0 = p.bg


### PR DESCRIPTION
Hello!

I really like this colorscheme but noticed it was missing highlights for the [mini.statusline plugin](https://github.com/echasnovski/mini.statusline). I have added the relevant highlight groups to highlights.lua, using the same colors used for lualine:
<details>
<summary>image preview</summary>

![image](https://github.com/user-attachments/assets/0cbdcc1b-e85d-4ff7-bc02-b367711fee52)

</details>


Feel free to make any changes or dismiss this PR if you aren't interested. In any case have a good day 🙂